### PR TITLE
Update aws-autoscaling.json

### DIFF
--- a/aws-autoscaling/aws-autoscaling.json
+++ b/aws-autoscaling/aws-autoscaling.json
@@ -461,7 +461,7 @@
         "multi": false,
         "name": "autoscalinggroupname",
         "options": [],
-        "query": "dimension_values($region, AWS/CloudFront, GroupTotalInstances, AutoScalingGroupName)",
+        "query": "dimension_values($region, AWS/AutoScaling, GroupTotalInstances, AutoScalingGroupName)",
         "refresh": 1,
         "regex": "",
         "sort": 0,


### PR DESCRIPTION
Doesn't seem to show the ASG names when using CloudFront as the dimension