### PR TITLE
removed ServiceName dimension from CPUUtilization & MemoryUtilization…

### DIFF
--- a/aws-ecs/aws-ecs.json
+++ b/aws-ecs/aws-ecs.json
@@ -93,8 +93,7 @@
           "targets": [
             {
               "dimensions": {
-                "ClusterName": "$cluster",
-                "ServiceName": "$service"
+                "ClusterName": "$cluster"
               },
               "metricName": "CPUUtilization",
               "namespace": "AWS/ECS",
@@ -179,8 +178,7 @@
           "targets": [
             {
               "dimensions": {
-                "ClusterName": "$cluster",
-                "ServiceName": "$service"
+                "ClusterName": "$cluster"
               },
               "metricName": "MemoryUtilization",
               "namespace": "AWS/ECS",


### PR DESCRIPTION
Removed "ServiceName": "$service" as default choices for CPUUtilization and MemoryUtilization since they give off error if not chosen.