### PR TITLE
README.md: Removed unwanted linebreak

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,7 @@ done
 ```
 
 Use [AWS Policy Generator](http://awspolicygen.s3.amazonaws.com/policygen.html),
-which fits your needs. Example of minimal IAM role for Grafana (CloudWatch
-+ EC2 metrics):
+which fits your needs. Example of minimal IAM role for Grafana (CloudWatch + EC2 metrics):
 
 ```
 {


### PR DESCRIPTION
Hi,
the line break before the "+" sign would start a new list in markdown. This is probably not what we want there.

Best,
Felix