### PR TITLE
aws-api-gateway: Improve $stage variable query

### DIFF
--- a/aws-api-gateway/aws-api-gateway.json
+++ b/aws-api-gateway/aws-api-gateway.json
@@ -862,7 +862,7 @@
         "multi": false,
         "name": "stage",
         "options": [],
-        "query": "dimension_values($region,AWS/ApiGateway,Count,Stage)",
+        "query": "dimension_values($region,AWS/ApiGateway,Count,Stage, {\"ApiName\": \"$apiname\"})",
         "refresh": 1,
         "regex": "",
         "sort": 0,


### PR DESCRIPTION
Improves the  `$stage` query by listing only existing stages in the selected `$apiname`.