### PR TITLE
Undo ECS dashboard change

### DIFF
--- a/aws-ecs/aws-ecs.json
+++ b/aws-ecs/aws-ecs.json
@@ -93,7 +93,8 @@
           "targets": [
             {
               "dimensions": {
-                "ClusterName": "$cluster"
+                "ClusterName": "$cluster",
+                "ServiceName": "$service"
               },
               "metricName": "CPUUtilization",
               "namespace": "AWS/ECS",
@@ -178,7 +179,8 @@
           "targets": [
             {
               "dimensions": {
-                "ClusterName": "$cluster"
+                "ClusterName": "$cluster",
+                "ServiceName": "$service"
               },
               "metricName": "MemoryUtilization",
               "namespace": "AWS/ECS",

--- a/aws-ecs/aws-ecs.json
+++ b/aws-ecs/aws-ecs.json
@@ -151,6 +151,91 @@
             "threshold2": null,
             "threshold2Color": "rgba(234, 112, 112, 0.22)"
           },
+          "id": 6,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 12,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "dimensions": {
+                "ClusterName": "$cluster"
+              },
+              "metricName": "CPUUtilization",
+              "namespace": "AWS/ECS",
+              "period": "",
+              "refId": "A",
+              "region": "$region",
+              "statistics": [
+                "Average"
+              ]
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "CPUUtilization (cluster $cluster)",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "show": true
+          },
+          "yaxes": [
+            {
+              "format": "percent",
+              "label": null,
+              "logBase": 1,
+              "max": 100,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ]
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "${DS_CLOUDWATCH}",
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
           "id": 2,
           "isNew": true,
           "legend": {
@@ -195,6 +280,91 @@
           "timeFrom": null,
           "timeShift": null,
           "title": "MemoryUtilization (cluster $cluster, service $service)",
+          "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "show": true
+          },
+          "yaxes": [
+            {
+              "format": "percent",
+              "label": null,
+              "logBase": 1,
+              "max": 100,
+              "min": 0,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ]
+        },
+      {
+          "aliasColors": {},
+          "bars": false,
+          "datasource": "${DS_CLOUDWATCH}",
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {
+            "threshold1": null,
+            "threshold1Color": "rgba(216, 200, 27, 0.27)",
+            "threshold2": null,
+            "threshold2Color": "rgba(234, 112, 112, 0.22)"
+          },
+          "id": 7,
+          "isNew": true,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "span": 12,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "dimensions": {
+                "ClusterName": "$cluster"
+              },
+              "metricName": "MemoryUtilization",
+              "namespace": "AWS/ECS",
+              "period": "",
+              "refId": "A",
+              "region": "$region",
+              "statistics": [
+                "Average"
+              ]
+            }
+          ],
+          "timeFrom": null,
+          "timeShift": null,
+          "title": "MemoryUtilization (cluster $cluster)",
           "tooltip": {
             "msResolution": true,
             "shared": true,


### PR DESCRIPTION
The changes to the ECS dashboard in #10 (related issue #9) broke support for individual service metrics on the ECS dashboard (#60).

This PR reverts the original PR, then adds back two panels that have the effect of the original PR, without destroying the valuable per-service metrics functionality that was removed with #10.

This should satisfy both the people for whom service-less ECS metrics are valuable and those for whom service-specific ECS metrics are valuable without interfering with the functionality of either.