### PR TITLE
Feature: A way to import all AWS dashboards under a grafana folder #76

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Import all Monitoring Artist AWS dashboards in one go (example script,
 
 ```bash
 #!/bin/bash
+jq --version >/dev/null 2>&1 || { echo >&2 "I require jq but it's not installed.  Aborting."; exit 1; }
 ### Please edit grafana_* variables to match your Grafana setup:
 grafana_host="http://localhost:3000"
 grafana_cred="admin:admin"

--- a/README.md
+++ b/README.md
@@ -24,15 +24,21 @@ Import all Monitoring Artist AWS dashboards in one go (example script,
 grafana_host="http://localhost:3000"
 grafana_cred="admin:admin"
 grafana_datasource="cloudwatch"
+# Keep grafana_folder empty for adding the dashboards in "General" folder
+grafana_folder="AWS CloudWatch"
 ds=(1516 677 139 674 590 659 758 623 617 551 653 969 650 644 607 593 707 575 1519 581 584 2969 8050 11099 11154 11155);
+folderId=$(curl -s -k -u "$grafana_cred" $grafana_host/api/folders | jq -r --arg grafana_folder  "$grafana_folder" '.[] | select(.title==$grafana_folder).id')
+if [ -z "$folderId" ] ; then echo "Didn't get folderId" ; else echo "Got folderId $folderId" ; fi
 for d in "${ds[@]}"; do
   echo -n "Processing $d: "
   j=$(curl -s -k -u "$grafana_cred" $grafana_host/api/gnet/dashboards/$d | jq .json)
+  payload="{\"dashboard\":$j,\"overwrite\":true,"
+  if [ ! -z "$folderId" ] ; then payload="${payload} \"folderId\": $folderId, " ; fi
+  payload="${payload} \"inputs\":[{\"name\":\"DS_CLOUDWATCH\",\"type\":\"datasource\", \
+        \"pluginId\":\"cloudwatch\",\"value\":\"$grafana_datasource\"}]}"
   curl -s -k -u "$grafana_cred" -XPOST -H "Accept: application/json" \
     -H "Content-Type: application/json" \
-    -d "{\"dashboard\":$j,\"overwrite\":true, \
-        \"inputs\":[{\"name\":\"DS_CLOUDWATCH\",\"type\":\"datasource\", \
-        \"pluginId\":\"cloudwatch\",\"value\":\"$grafana_datasource\"}]}" \
+    -d "$payload" \
     $grafana_host/api/dashboards/import; echo ""
 done
 ```


### PR DESCRIPTION
Import all grafana dashboard under a folder option.

If the variable is `grafana_folder` is not defined then it'll import in General folder aka root.

Also, I have a check if jq(https://github.com/stedolan/jq/) package is present at the start.

Issue: https://github.com/monitoringartist/grafana-aws-cloudwatch-dashboards/issues/76