### PR TITLE
plugins, datasource no longer required

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ jq --version >/dev/null 2>&1 || { echo >&2 "I require jq but it's not installed.
 ### Please edit grafana_* variables to match your Grafana setup:
 grafana_host="http://localhost:3000"
 grafana_cred="admin:admin"
-grafana_datasource="cloudwatch"
 # Keep grafana_folder empty for adding the dashboards in "General" folder
 grafana_folder="AWS CloudWatch"
 ds=(1516 677 139 674 590 659 758 623 617 551 653 969 650 644 607 593 707 575 1519 581 584 2969 8050 11099 11154 11155);
@@ -33,10 +32,8 @@ if [ -z "$folderId" ] ; then echo "Didn't get folderId" ; else echo "Got folderI
 for d in "${ds[@]}"; do
   echo -n "Processing $d: "
   j=$(curl -s -k -u "$grafana_cred" $grafana_host/api/gnet/dashboards/$d | jq .json)
-  payload="{\"dashboard\":$j,\"overwrite\":true,"
-  if [ ! -z "$folderId" ] ; then payload="${payload} \"folderId\": $folderId, " ; fi
-  payload="${payload} \"inputs\":[{\"name\":\"DS_CLOUDWATCH\",\"type\":\"datasource\", \
-        \"pluginId\":\"cloudwatch\",\"value\":\"$grafana_datasource\"}]}"
+  payload="{\"dashboard\":$j,\"overwrite\":true"
+  if [ ! -z "$folderId" ] ; then payload="${payload}, \"folderId\": $folderId }";  else payload="${payload} }" ; fi
   curl -s -k -u "$grafana_cred" -XPOST -H "Accept: application/json" \
     -H "Content-Type: application/json" \
     -d "$payload" \

--- a/aws-rds/aws-rds.json
+++ b/aws-rds/aws-rds.json
@@ -1,14 +1,5 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_CLOUDWATCH",
-      "label": "CloudWatch",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "cloudwatch",
-      "pluginName": "CloudWatch"
-    }
-  ],
+  "__inputs": [],
   "__requires": [
     {
       "type": "datasource",


### PR DESCRIPTION
Minor: https://github.com/monitoringartist/grafana-aws-cloudwatch-dashboards/issues/76

Also, shall I change `/api/dashboards/import` to `/api/dashboards/db` as this works and [official documentation](https://grafana.com/docs/grafana/latest/http_api/dashboard/#create--update-dashboard) says so.

I couldn't find any documentation saying to use this `/api/dashboards/import`.