### PR TITLE
Dashboard regions to be default, selected at datasoruce

### DIFF
--- a/aws-api-gateway/aws-api-gateway.json
+++ b/aws-api-gateway/aws-api-gateway.json
@@ -965,7 +965,7 @@
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
-        "sort": 1,
+        "sort": 0,
         "tagValuesQuery": "",
         "tags": [],
         "tagsQuery": "",

--- a/aws-cloudwatch-browser/aws-cloudwatch-browser.json
+++ b/aws-cloudwatch-browser/aws-cloudwatch-browser.json
@@ -357,7 +357,7 @@
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
-        "sort": 1,
+        "sort": 0,
         "tagValuesQuery": "",
         "tags": [],
         "tagsQuery": "",

--- a/aws-codebuild/aws-codebuild.json
+++ b/aws-codebuild/aws-codebuild.json
@@ -884,7 +884,7 @@
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
-        "sort": 1,
+        "sort": 0,
         "tagValuesQuery": "",
         "tags": [],
         "tagsQuery": "",

--- a/aws-lambda/aws-lambda.json
+++ b/aws-lambda/aws-lambda.json
@@ -947,7 +947,7 @@
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
-        "sort": 1,
+        "sort": 0,
         "tagValuesQuery": "",
         "tags": [],
         "tagsQuery": "",

--- a/aws-redshift/aws-redshift.json
+++ b/aws-redshift/aws-redshift.json
@@ -1179,7 +1179,7 @@
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
-        "sort": 1,
+        "sort": 0,
         "tagValuesQuery": "",
         "tags": [],
         "tagsQuery": "",

--- a/aws-route-53/aws-route-53.json
+++ b/aws-route-53/aws-route-53.json
@@ -692,7 +692,7 @@
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
-        "sort": 1,
+        "sort": 0,
         "tagValuesQuery": "",
         "tags": [],
         "tagsQuery": "",

--- a/aws-s3/aws-s3.json
+++ b/aws-s3/aws-s3.json
@@ -1198,7 +1198,7 @@
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
-        "sort": 1,
+        "sort": 0,
         "tagValuesQuery": "",
         "tags": [],
         "tagsQuery": "",

--- a/aws-step-functions/aws-step-functions.json
+++ b/aws-step-functions/aws-step-functions.json
@@ -1138,7 +1138,7 @@
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
-        "sort": 1,
+        "sort": 0,
         "tagValuesQuery": "",
         "tags": [],
         "tagsQuery": "",


### PR DESCRIPTION
sort=0, which is `Disable` instead of sort=1 which is `Alphabetic(asc)` for region variable to select `default`.

So, whenever the dashboard loads `region` is set to the value set at the DataSource label for the data source.

This make a bad experience for the end-user. For example, the default region is `us-east-1` for them but everytime they open the dashboard they have to manually select `us-east-1` from `ap-east-1`, Alphabetic(asc).

Also, please update these 

1. AWS API Gateway: https://grafana.com/grafana/dashboards/1516
2. AWS Cloudwatch Browser: https://grafana.com/grafana/dashboards/590
3. AWS CodeBuild: https://grafana.com/grafana/dashboards/11155
4. AWS Lambda: https://grafana.com/grafana/dashboards/593
5. AWS Redshift: https://grafana.com/grafana/dashboards/8050
6. AWS Route 53: https://grafana.com/grafana/dashboards/11154
7. AWS S3: https://grafana.com/grafana/dashboards/575
8. AWS Step Functions: https://grafana.com/grafana/dashboards/11099
