### PR TITLE
CoreNodesRunning is not populating the JobFlowid

### DIFF
--- a/aws-emr/aws-emr-hadoop-2.json
+++ b/aws-emr/aws-emr-hadoop-2.json
@@ -1662,7 +1662,7 @@
         "multi": false,
         "name": "jobflowid",
         "options": [],
-        "query": "dimension_values($region,AWS/ElasticMapReduce,CoreNodesRunning,JobFlowId)",
+        "query": "dimension_values($region,AWS/ElasticMapReduce,IsIdle,JobFlowId)",
         "refresh": 1,
         "type": "query"
       }


### PR DESCRIPTION
Changing to default Metrics like IsIdle to populate the list of Jobid as per https://docs.aws.amazon.com/emr/latest/ManagementGuide/UsingEMR_ViewingMetrics.html