### PR TITLE
Fix format from megabytes to bytes in RDS

### DIFF
--- a/aws-rds/aws-rds.json
+++ b/aws-rds/aws-rds.json
@@ -1672,7 +1672,7 @@
       },
       "yaxes": [
         {
-          "format": "decmbytes",
+          "format": "bytes",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -1836,7 +1836,7 @@
       },
       "yaxes": [
         {
-          "format": "decmbytes",
+          "format": "bytes",
           "label": null,
           "logBase": 1,
           "max": null,


### PR DESCRIPTION
Fix format from megabytes to bytes in RDS dashboard for a couple of params